### PR TITLE
Adding weightHP query option to functions

### DIFF
--- a/neuprint/queries.py
+++ b/neuprint/queries.py
@@ -538,7 +538,7 @@ def fetch_simple_connections(upstream_criteria=None, downstream_criteria=None, r
     down_crit = copy.deepcopy(downstream_criteria)
 
     weight_type = "weight"
-    if weightHP is True:
+    if weightHP:
         weight_type = "weightHP"
     
     if up_crit is None:
@@ -1255,7 +1255,7 @@ def fetch_shortest_paths(upstream_bodyId, downstream_bodyId, min_weight=1,
             [5778 rows x 4 columns]
     """
     weight_type = "weight"
-    if weightHP is True:
+    if weightHP:
         weight_type = "weightHP"
     
     if intermediate_criteria is None:


### PR DESCRIPTION
Adding `weightHP` query option to `fetch_shortest_paths` and `fetch_simple_connections`, etc.

See #25

## TODO

The following functions will all need to be updated to support a high-precision option.

- [x] `fetch_adjacencies()`
- [x] `fetch_traced_adjacencies()`
- [x] `fetch_simple_connections()`
- [x] `fetch_common_connectivity()`
    - Add `roi` parameter, too.
    - Fix pre-existing bug (see below).
- [x] `fetch_shortest_paths()`
- [x] `fetch_output_completeness()`
- [ ] ~`fetch_downstream_orphan_tasks()`~
    - Let's not bother with this one for now.

Updating the following functions will require a more significant change to the API, since they don't use `weightHP`.  They inspect synapses individually, but I think it would be best to aim for conceptual consistency with the above functions if possible.  Perhaps these updates should be deferred for now, and implemented in a separate pull request.

- [ ] `fetch_synapse_connections()`
- [ ] `fetch_connection_mitochondria()`

Documentation updates:

- [x] Update docstrings for all edited functions.
- [x] Update `docs/source/changelog.rst`
- [x] Maybe add a new entry in `docs/source/faq.rst`?