### PR TITLE
add backticks to return statements

### DIFF
--- a/neuprint/queries/neurons.py
+++ b/neuprint/queries/neurons.py
@@ -117,7 +117,7 @@ def fetch_neurons(criteria, *, client=None):
     # return properties individually to avoid a large JSON payload.
     # (Returning a map on every row is ~2x more costly than returning a table of rows/columns.)
     props = compile_columns(client, core_columns=CORE_NEURON_COLS)
-    return_exprs = ',\n'.join(f'n.{prop} as {prop}' for prop in props)
+    return_exprs = ',\n'.join(f'n.`{prop}` as `{prop}`' for prop in props)
     return_exprs = indent(return_exprs, ' '*15)[15:]
 
     q = f"""\


### PR DESCRIPTION
property names can now contain special characters, for example "-" as seen in recent database.

see https://neo4j.com/docs/cypher-manual/current/syntax/naming/