### PR TITLE
Fixed bug in connection_table_to_matrix when make_square=True

### DIFF
--- a/neuprint/utils.py
+++ b/neuprint/utils.py
@@ -321,7 +321,9 @@ def connection_table_to_matrix(conn_df, group_cols='bodyId', weight_col='weight'
         matrix = matrix.reindex(index=pre_order, columns=post_order)
 
     if make_square:
-        matrix, _ = matrix.align(matrix.T).fillna(0.0).astype(matrix.dtype)
+        matrix, _ = matrix.align(matrix.T)
+        matrix = matrix.fillna(0.0).astype(matrix.dtypes)
+
         matrix = matrix.rename_axis('bodyId_pre', axis=0).rename_axis('bodyId_post', axis=1)
         matrix = matrix.loc[sorted(matrix.index), sorted(matrix.columns)]
 


### PR DESCRIPTION
When running `connection_table_to_matrix(connection_df_pre, 'bodyId', sort_by='type', make_square=True)`, the following error is thrown: `AttributeError: 'tuple' object has no attribute 'fillna'`

This is due to an issue with tuple unpacking in the following one-liner:
`matrix, _ = matrix.align(matrix.T).fillna(0.0).astype(matrix.dtype)`

I have modified only the conditional block of code to fix this issue.