### PR TITLE
neurotransmitter API

### DIFF
--- a/neuprint/client.py
+++ b/neuprint/client.py
@@ -701,6 +701,28 @@ class Client:
             neuron_props_json = ujson.loads(neuron_props_val)
             neuron_props = list(neuron_props_json.keys())
             return neuron_props
+
+    @lru_cache
+    def fetch_synapse_nt_keys(self):
+        """
+        Returns :Synapse properties related to neurotransmitters. Cached.
+        """
+
+        # hard-coded CNS reply until we populate the db:
+        return ["ntAcetylcholineProb", "ntDopamineProb", "ntGabaProb",
+                "ntGlutamateProb", "ntHistamineProb", "ntOctopamineProb", "ntSerotoninProb"]
+
+        # like fetch_neuron_keys(), but no fallback query
+        b = "MATCH (n:Meta) RETURN n.ntSynapseProperties"
+        df_results = self.fetch_custom(b)
+        synapse_props_val = df_results.iloc[0, 0]
+        if synapse_props_val is None:
+            return []
+        else:
+            synapse_props_json = ujson.loads(synapse_props_val)
+            synapse_props = list(synapse_props_json.keys())
+            return sorted(synapse_props)
+
     ##
     ## DB-META
     ##

--- a/neuprint/queries/synapses.py
+++ b/neuprint/queries/synapses.py
@@ -159,10 +159,14 @@ def _fetch_synapses(neuron_criteria, synapse_criteria, nt, client):
 
     # Neurotransmitters vary by dataset; get the names and dynamically
     #   insert the column names into the cypher query.
-    synapse_nt_prop_names = client.fetch_synapse_nt_keys()
-    if not synapse_nt_prop_names:
-        # no data = ignore this parameter
-        nt = None
+    synapse_nt_prop_names = []
+    if nt:
+        synapse_nt_prop_names = client.fetch_synapse_nt_keys()
+        if not synapse_nt_prop_names:
+            raise RuntimeError(
+                "Can't return synapse neurotransmitter properties: "
+                "No neurotransmitter properties found in the database."
+            )
 
     # Fetch results
     cypher = dedent(f"""\
@@ -714,10 +718,14 @@ def _fetch_synapse_connections(source_criteria, target_criteria, synapse_criteri
 
     # Neurotransmitters vary by dataset; get the names and dynamically
     #   insert the column names into the cypher query.
-    synapse_nt_prop_names = client.fetch_synapse_nt_keys()
-    if not synapse_nt_prop_names:
-        # no data = ignore this parameter
-        nt = None
+    synapse_nt_prop_names = []
+    if nt:
+        synapse_nt_prop_names = client.fetch_synapse_nt_keys()
+        if not synapse_nt_prop_names:
+            raise RuntimeError(
+                "Can't return synapse neurotransmitter properties: "
+                "No neurotransmitter properties found in the database."
+            )
 
     # Fetch results
     cypher = dedent(f"""\

--- a/neuprint/queries/synapses.py
+++ b/neuprint/queries/synapses.py
@@ -43,7 +43,7 @@ def fetch_synapses(neuron_criteria, synapse_criteria=None, batch_size=10, *, nt=
             will be fetched in batches, where each batch corresponds to N bodies.
             This argument sets the batch size N.
 
-        neurotransmitters (None (default), 'max', or 'all'):
+        nt (None (default), 'max', or 'all'):
             Optional. Retrieves neurotransmitter information for each "pre" synapse.
 
             If None, no neurotransmitter information is retrieved.


### PR DESCRIPTION
This pull request will stay in draft form for a while as we discuss the implementation.

Right now `fetch_synapses()` has been updated to return neurotransmitters on demand and is working. The implementation does all of the nt processing and formatting in Python rather than Cypher. `fetch_synapse_connectivity()` is not done, nor are tests.

However, after our discussion, I think I prefer your suggestion of putting `synapseProperties` in the `:Meta` node and building the proper Cypher queries in code, just like we do for neurons. We could sniff the properties in a separate query and cache them, but I like the consistency of putting them in the `:Meta` node. 

Minor note: if you have a better column name than `ntWithMaxProb`, I would like to hear it. `ntMaxProb` sounds like it's the maximum probability, not the nt with max prob. Ideas?