### PR TITLE
integrate `fetch_paths()` function from pull request #57

### DIFF
--- a/docs/source/queries.rst
+++ b/docs/source/queries.rst
@@ -71,6 +71,7 @@ Connectivity
     fetch_adjacencies
     fetch_traced_adjacencies
     fetch_common_connectivity
+    fetch_paths
     fetch_shortest_paths
 
 Synapses

--- a/neuprint/__init__.py
+++ b/neuprint/__init__.py
@@ -4,7 +4,7 @@ import platform
 from .client import Client, default_client, set_default_client, clear_default_client, list_all_clients
 from .queries import ( fetch_custom, fetch_meta, fetch_all_rois, fetch_primary_rois, fetch_roi_hierarchy,
                        fetch_neurons, fetch_custom_neurons, fetch_simple_connections, fetch_adjacencies,
-                       fetch_traced_adjacencies, fetch_common_connectivity, fetch_shortest_paths,
+                       fetch_traced_adjacencies, fetch_common_connectivity, fetch_paths, fetch_shortest_paths,
                        fetch_mitochondria, fetch_synapses_and_closest_mitochondria, fetch_connection_mitochondria,
                        fetch_synapses, fetch_mean_synapses, fetch_synapse_connections, fetch_output_completeness,
                        fetch_downstream_orphan_tasks,

--- a/neuprint/queries/__init__.py
+++ b/neuprint/queries/__init__.py
@@ -5,7 +5,7 @@ from .general import fetch_custom, fetch_meta
 from .rois import fetch_all_rois, fetch_primary_rois,fetch_roi_hierarchy
 from .neurons import fetch_neurons, fetch_custom_neurons
 from .connectivity import (fetch_simple_connections, fetch_adjacencies, fetch_traced_adjacencies,
-                           fetch_common_connectivity, fetch_shortest_paths)
+                           fetch_common_connectivity, fetch_paths, fetch_shortest_paths)
 from .synapses import fetch_synapses, fetch_mean_synapses, fetch_synapse_connections
 from .mito import fetch_mitochondria, fetch_synapses_and_closest_mitochondria, fetch_connection_mitochondria
 from .recon import fetch_output_completeness, fetch_downstream_orphan_tasks

--- a/neuprint/tests/test_queries.py
+++ b/neuprint/tests/test_queries.py
@@ -8,7 +8,7 @@ from neuprint import (NeuronCriteria as NC,
                       SynapseCriteria as SC,
                       fetch_custom, fetch_neurons, fetch_meta,
                       fetch_all_rois, fetch_primary_rois, fetch_simple_connections,
-                      fetch_adjacencies, fetch_shortest_paths,
+                      fetch_adjacencies, fetch_shortest_paths, fetch_paths,
                       fetch_mitochondria, fetch_synapses_and_closest_mitochondria,
                       fetch_synapses, fetch_mean_synapses, fetch_synapse_connections)
 
@@ -126,6 +126,33 @@ def test_fetch_shortest_paths(client):
     assert (paths_df.groupby('path')['bodyId'].last() == dst).all()
 
     assert (paths_df.groupby('path')['weight'].first() == 0).all()
+
+def test_fetch_paths_exact(client):
+    src = 329566174
+    dst = 294792184
+    paths_df = fetch_paths(src, dst, path_length=2, min_weight=10, timeout=3)
+    assert (paths_df.groupby('path')['bodyId'].first() == src).all()
+    assert (paths_df.groupby('path')['bodyId'].last() == dst).all()
+
+    assert "path_length" in paths_df.columns
+    assert (paths_df['path_length'] == 2).all()
+
+def test_fetch_paths_limited(client):
+    src = 329566174
+    dst = 294792184
+    paths_df = fetch_paths(src, dst, max_path_length=2, min_weight=10, timeout=3)
+    assert (paths_df.groupby('path')['bodyId'].first() == src).all()
+    assert (paths_df.groupby('path')['bodyId'].last() == dst).all()
+
+    assert "path_length" in paths_df.columns
+    assert (paths_df['path_length'] <= 2).all()
+
+def test_fetch_paths_input(client):
+    src = 329566174
+    dst = 294792184
+    with pytest.raises(ValueError):
+        # path_length and max_path_length are mutually exclusive
+        fetch_paths(src, dst, path_length=2, max_path_length=2, min_weight=10, timeout=3)
 
 
 @pytest.mark.skip


### PR DESCRIPTION
I've taken code from `artxz`'s pull request #57. I integrated the Cypher changes into our existing `fetch_shortest_path()` function, controlling the behavior via input parameter. I've preserved the existing `fetch_shortest_path()` as a convenience wrapper around the new `fetch_paths()` function that can find paths that aren't the shortest (exact length or up to a given length). Tests added. 

Admittedly my ability to test for correctness is limited. I tested with `shortest` (matches old behavior), `exact` (matches the docstring output in the pull), and `max` (behaves rationally as you vary the parameters).