### PR TITLE
76 documentation search

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
+    'sphinxcontrib.jquery',  # required for search and nav functions
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
     'nbsphinx'

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -8,6 +8,8 @@ Notes for maintaining ``neuprint-python``.
 Prerequisites
 -------------
 
+**For general development:**
+
 Make sure you have both ``flyem-forge`` and ``conda-forge`` listed as channels in your ``.condarc`` file.
 (If you don't know where your ``.condarc`` file is, check ``conda config --show-sources``.)
 
@@ -18,6 +20,8 @@ Make sure you have both ``flyem-forge`` and ``conda-forge`` listed as channels i
     - flyem-forge
     - conda-forge
     - nodefaults  # A magic channel that forbids any downloads from the anaconda default channels.
+
+**For packaging and release:**
 
 Install ``conda-build`` if you don't have it yet:
 
@@ -129,7 +133,10 @@ follow these steps **on a Linux machine**:
 Documentation
 -------------
 
-The docs are built with Sphinx.  See ``docs/requirements.txt`` for the docs dependencies.
+The docs are built with Sphinx.  See ``docs/requirements.txt`` for the docs dependencies (in addition to those listed in ``dependencies.txt``). In addition, building the docs requires the ``pandoc`` command-line tool to be installed in the environment (the Python wrapper, though, is not required).
+
+The example notebooks are run when the docs are built. For this to succeed, the ``neuprint`` library must be on your ``PYTHONPATH``. Like the tests, the docs rely on the public ``hemibrain:v1.2.1`` dataset on ``neuprint.janelia.org``, which means you must define ``NEUPRINT_APPLICATION_CREDENTIALS`` in your environment before running them.
+
 To build the docs locally:
 
 .. code-block:: bash


### PR DESCRIPTION
Fixed doc search. 

Sphinx doesn't package jQuery anymore, so themes that use it like our `sphinx_rtd_theme` must enable it by adding it to the extensions list.

I also improved the docs for building docs, including these important points:
- need `pandoc` CLI tool installed (but the Python wrapper is not required)
- need `neuprint` on the `PYTHONPATH`
- need `NEUPRINT_APPLICATION_CREDENTIALS` so you can run the tutorial notebooks and generate their html