### PR TITLE
added `returned_columns` parameter to `fetch_neurons()`

### DIFF
--- a/neuprint/tests/test_queries.py
+++ b/neuprint/tests/test_queries.py
@@ -12,6 +12,7 @@ from neuprint import (NeuronCriteria as NC,
                       fetch_mitochondria, fetch_synapses_and_closest_mitochondria,
                       fetch_synapses, fetch_mean_synapses, fetch_synapse_connections)
 
+from neuprint.queries.neurons import CORE_NEURON_COLS
 from neuprint.tests import NEUPRINT_SERVER, DATASET
 
 @pytest.fixture(scope='module')
@@ -78,6 +79,15 @@ def test_fetch_neurons(client):
 
     neurons, roi_counts = fetch_neurons(NC(min_pre=1000, min_post=2000))
     assert neurons.eval('pre >= 1000 and post >= 2000').all()
+
+    neurons, roi_counts = fetch_neurons(NC(bodyId=bodyId), returned_columns="core")
+    # hemibrain dataset has all the CORE_NEURON_COLS
+    assert set(neurons.columns) == set(CORE_NEURON_COLS)
+
+    requested_columns = ['bodyId', 'instance']
+    neurons = fetch_neurons(NC(bodyId=bodyId), returned_columns=requested_columns, omit_rois=True)
+    assert set(neurons.columns) == set(requested_columns)
+
 
 
 def test_fetch_simple_connections(client):


### PR DESCRIPTION
Added `returned_columns` parameter to `fetch_neurons()`. Valid options are:
- "all": returns all existing columns
- "core": returns columns in `CORE_NEURON_COLS` from `neurons.py`, if they exist
- user-supplied list: returns those columns, if they exist

In all cases, columns that don't exist are ignored. If requested, core columns will appear before the rest, which will appear in sorted order.

Added unit tests but tested more combinations by hand.