### PR TITLE
Allow disabling progress bars via Client

### DIFF
--- a/neuprint/client.py
+++ b/neuprint/client.py
@@ -366,7 +366,7 @@ class Client:
     """
     Client object for interacting with the neuprint database.
     """
-    def __init__(self, server, dataset=None, token=None, verify=True):
+    def __init__(self, server, dataset=None, token=None, verify=True, progress=True):
         """
         When you create the first ``Client``, it becomes the default
         ``Client`` to be used with all ``neuprint-python`` functions
@@ -392,7 +392,13 @@ class Client:
                 The dataset to run all queries against, e.g. 'hemibrain'.
                 If not provided, the server will use a default dataset for
                 all queries.
+
+            progress:
+                If ``True`` (default), show progress bars for long queries.
+
         """
+        self.progress = progress
+
         if not token:
             token = os.environ.get('NEUPRINT_APPLICATION_CREDENTIALS')
 
@@ -491,7 +497,7 @@ class Client:
     def _fetch_json(self, url, json=None, ispost=False):
         r = self._fetch(url, json=json, ispost=ispost)
         return ujson.loads(r.content)
-    
+
     def _fetch_arrow(self, url, json=None, ispost=False):
         r = self._fetch(url, json=json, ispost=ispost)
         content_type = r.headers.get('Content-Type', '')
@@ -625,10 +631,10 @@ class Client:
     def fetch_version(self):
         """
         Returns the version of the ``neuPrintHTTP`` server.
-        
+
         Returns:
             str: The server version as a string.
-            
+
         Raises:
             HTTPError: If the version endpoint is not found or returns an error.
             KeyError: If the response doesn't contain a 'Version' key.
@@ -640,11 +646,11 @@ class Client:
         except (HTTPError, KeyError, Exception) as e:
             # Let the caller handle the exception
             raise
-        
+
     def arrow_endpoint(self):
         """
         Checks if the neuPrintHTTP server version supports Arrow IPC via HTTP.
-        
+
         Returns:
             bool: True if the server version is 1.7.3 or higher, False otherwise.
         """
@@ -652,11 +658,11 @@ class Client:
             version_str = self.fetch_version()
             if not version_str:
                 return False
-                
+
             # Parse semantic version
             server_version = version.parse(version_str)
             min_version = version.parse('1.7.3')
-            
+
             return server_version >= min_version
         except (HTTPError, KeyError, Exception):
             # If we can't determine the version for any reason, default to False

--- a/neuprint/queries/connectivity.py
+++ b/neuprint/queries/connectivity.py
@@ -431,7 +431,7 @@ def fetch_adjacencies(sources=None, targets=None, rois=None, min_roi_weight=1, m
 
         if sources_df is not None:
             # Break sources into batches
-            for batch_start in trange(0, len(sources_df), batch_size):
+            for batch_start in trange(0, len(sources_df), batch_size, disable=not client.progress):
                 batch_stop = batch_start + batch_size
                 source_bodies = sources_df['bodyId'].iloc[batch_start:batch_stop].tolist()
 
@@ -466,7 +466,7 @@ def fetch_adjacencies(sources=None, targets=None, rois=None, min_roi_weight=1, m
                     conn_tables.append(t)
         else:
             # Break targets into batches
-            for batch_start in trange(0, len(targets_df), batch_size):
+            for batch_start in trange(0, len(targets_df), batch_size, disable=not client.progress):
                 batch_stop = batch_start + batch_size
                 target_bodies = targets_df['bodyId'].iloc[batch_start:batch_stop].tolist()
 
@@ -609,7 +609,7 @@ def fetch_adjacencies(sources=None, targets=None, rois=None, min_roi_weight=1, m
     missing_bodies = [*set(connected_bodies) - set(neurons_df['bodyId'])]
 
     batches = []
-    for start in trange(0, len(missing_bodies), 10_000):
+    for start in trange(0, len(missing_bodies), 10_000, disable=not client.progress):
         batch_bodies = missing_bodies[start:start+10_000]
         batch_df = _fetch_neurons(NeuronCriteria(bodyId=batch_bodies, label=missing_label, client=client))
         batches.append( batch_df )

--- a/neuprint/queries/mito.py
+++ b/neuprint/queries/mito.py
@@ -93,7 +93,7 @@ def fetch_mitochondria(neuron_criteria, mito_criteria=None, batch_size=10, *, cl
     bodies = client.fetch_custom(q)['bodyId'].values
 
     batch_dfs = []
-    for batch_bodies in tqdm(iter_batches(bodies, batch_size)):
+    for batch_bodies in tqdm(iter_batches(bodies, batch_size), disable=not client.progress):
         batch_criteria = copy.copy(neuron_criteria)
         batch_criteria.bodyId = batch_bodies
         batch_df = _fetch_mitos(batch_criteria, mito_criteria, client)
@@ -270,7 +270,7 @@ def fetch_synapses_and_closest_mitochondria(neuron_criteria, synapse_criteria=No
     bodies = client.fetch_custom(q)['bodyId'].values
 
     batch_dfs = []
-    for batch_bodies in tqdm(iter_batches(bodies, batch_size)):
+    for batch_bodies in tqdm(iter_batches(bodies, batch_size), disable=not client.progress):
         batch_criteria = copy.copy(neuron_criteria)
         batch_criteria.bodyId = batch_bodies
         batch_df = _fetch_synapses_and_closest_mitochondria(batch_criteria, synapse_criteria, client)

--- a/neuprint/queries/recon.py
+++ b/neuprint/queries/recon.py
@@ -48,7 +48,7 @@ def fetch_output_completeness(criteria, complete_statuses=['Traced'], batch_size
     bodies = fetch_custom(q)['bodyId']
 
     batch_results = []
-    for start in trange(0, len(bodies), batch_size):
+    for start in trange(0, len(bodies), batch_size, disable=not client.progress):
         criteria.bodyId = bodies[start:start+batch_size]
         _df = _fetch_output_completeness(criteria, complete_statuses, client)
         if len(_df) > 0:

--- a/neuprint/queries/synapses.py
+++ b/neuprint/queries/synapses.py
@@ -109,7 +109,7 @@ def fetch_synapses(neuron_criteria, synapse_criteria=None, batch_size=10, *, cli
     bodies = client.fetch_custom(q)['bodyId'].values
 
     batch_dfs = []
-    for batch_bodies in tqdm(iter_batches(bodies, batch_size)):
+    for batch_bodies in tqdm(iter_batches(bodies, batch_size), disable=not client.progress):
         batch_criteria = copy.copy(neuron_criteria)
         batch_criteria.bodyId = batch_bodies
         batch_df = _fetch_synapses(batch_criteria, synapse_criteria, client)
@@ -273,7 +273,7 @@ def fetch_mean_synapses(neuron_criteria, synapse_criteria=None, batch_size=100, 
     bodies = client.fetch_custom(q)['bodyId'].values
 
     batch_dfs = []
-    for batch_bodies in tqdm(iter_batches(bodies, batch_size)):
+    for batch_bodies in tqdm(iter_batches(bodies, batch_size), disable=not client.progress):
         batch_criteria = copy.copy(neuron_criteria)
         batch_criteria.bodyId = batch_bodies
         if by_roi:
@@ -598,10 +598,10 @@ def fetch_synapse_connections(source_criteria=None, target_criteria=None, synaps
         grouping_col = 'bodyId_post'
 
     syn_dfs = []
-    with tqdm(total=roi_conn_df['weight'].sum()) as progress:
+    with tqdm(total=roi_conn_df['weight'].sum(), disable=not client.progress) as progress:
         for _, group_df in conn_df.groupby(grouping_col):
             batches = iter_batches(group_df, batch_size)
-            for batch_df in tqdm(batches, leave=False):
+            for batch_df in tqdm(batches, leave=False, disable=not client.progress):
                 src_crit = copy.copy(source_criteria)
                 tgt_crit = copy.copy(target_criteria)
 

--- a/neuprint/simulation.py
+++ b/neuprint/simulation.py
@@ -401,7 +401,7 @@ class NeuronModel:
         self.bodyid = bodyid
 
 
-        with tqdm(total=100) as pbar:
+        with tqdm(total=100, disable=not client.progress) as pbar:
             # retrieve healed skeleton
             pbar.set_description("fetching skeleton")
             self.skeleton_df = client.fetch_skeleton(bodyid, heal=True)


### PR DESCRIPTION
This PR adds a `progress` parameter to `Client`. Setting `progress=False` (default is `True`) will suppress progress bars - e.g. when a query is run in batches.

I found this useful in cases where I run many small requests in a for loop which in the current implementation leads to a heap of completed progress bars.

Example:
```python
client = neu.Client(
    'https://neuprint.janelia.org',
    dataset='hemibrain:v1.2.1',
    progress=False
)
# This will now not show a progress bar.
syn = neu.fetch_synapse_connections(
    source_criteria=NeuronCriteria(type='ORN_DA1'),
    target_criteria=NeuronCriteria(type="DA1_lPN")
)
```