### PR TITLE
NeuronCriteria, etc: Don't hard-code the quotes around string values

### DIFF
--- a/neuprint/queries/mitocriteria.py
+++ b/neuprint/queries/mitocriteria.py
@@ -93,7 +93,7 @@ class MitoCriteria:
             size_expr = f'({self.matchvar}.size >= {self.size})'
 
         if self.mitoType:
-            mitoType_expr = f"({self.matchvar}.mitoType = '{self.mitoType}')"
+            mitoType_expr = f"({self.matchvar}.mitoType = {repr(self.mitoType)})"
 
         exprs = [*filter(None, [type_expr, roi_expr, size_expr, mitoType_expr])]
 
@@ -126,10 +126,10 @@ class MitoCriteria:
         args = []
 
         if self.rois:
-            args.append("rois=[" + ", ".join(f"'{roi}'" for roi in self.rois) + "]")
+            args.append("rois=[" + ", ".join(f"{repr(roi)}" for roi in self.rois) + "]")
 
         if self.mitoType:
-            args.append(f"mitoType='{self.mitoType}'")
+            args.append(f"mitoType={repr(self.mitoType)}")
 
         if self.size:
             args.append(f"size={self.size}")

--- a/neuprint/queries/synapsecriteria.py
+++ b/neuprint/queries/synapsecriteria.py
@@ -98,7 +98,7 @@ class SynapseCriteria:
             conf_expr = f'({self.matchvar}.confidence > {self.confidence})'
 
         if self.type:
-            type_expr = f"({self.matchvar}.type = '{self.type}')"
+            type_expr = f"({self.matchvar}.type = {repr(self.type)})"
 
         exprs = [*filter(None, [roi_expr, conf_expr, type_expr])]
 
@@ -129,10 +129,10 @@ class SynapseCriteria:
         args = []
 
         if self.rois:
-            args.append("rois=[" + ", ".join(f"'{roi}'" for roi in self.rois) + "]")
+            args.append("rois=[" + ", ".join(f"{repr(roi)}" for roi in self.rois) + "]")
 
         if self.type:
-            args.append(f"type='{self.type}'")
+            args.append(f"type={repr(self.type)}")
 
         if self.confidence:
             args.append(f"confidence={self.confidence}")

--- a/neuprint/tests/test_neuroncriteria.py
+++ b/neuprint/tests/test_neuroncriteria.py
@@ -58,6 +58,13 @@ def test_NeuronCriteria(client):
     assert NC(status=["foo", "bar"]).basic_exprs() == ["n.status in ['foo', 'bar']"]
     assert NC(status=["foo", "bar"], regex=True).basic_exprs() == ["n.status in ['foo', 'bar']"]
 
+    # Check that quotes and backslashes are escaped correctly.
+    assert NC(status="f\\oo").basic_exprs() == ["n.status = 'f\\\\oo'"]
+    assert NC(instance="fo'o").basic_exprs() == ["n.instance = \"fo'o\""]
+    assert NC(instance="fo'o", regex=True).basic_exprs() == ["n.instance =~ \"fo'o\""]
+    assert NC(instance=["fo'o", 'ba\"r']).basic_exprs() == ["n.instance in [\"fo'o\", 'ba\"r']"]
+    assert NC(instance=["fo'o", 'ba"r'], regex=True).basic_exprs() == ["n.instance =~ '(fo\\'o)|(ba\"r)'"]
+
     assert NC(cropped=True).basic_exprs() == ["n.cropped"]
     assert NC(cropped=False).basic_exprs() == ["(NOT n.cropped OR NOT exists(n.cropped))"]
 


### PR DESCRIPTION
Don't hard-code the quotes around string values -- that fails when the value contains quotes internally. Instead, rely on Python's `repr()` to choose the appropriate quoting and/or escaping for strings. (Cypher and Python happen to be compatible in this regard.)

This will fix errors that can arise when querying for cell types such as these ones as reported by @leburnett:

```
MBON01(y5B'2a)_R
MBON31(a'1a)_R
MBON09(y3B'1)_R
MBON26(b'2d)_L
MBON26(b'2d)_L
```

cc @olbris @StephanPreibisch